### PR TITLE
Correct getting start game forms

### DIFF
--- a/werewolf/werewolf/tests/test_game_management.py
+++ b/werewolf/werewolf/tests/test_game_management.py
@@ -5,6 +5,13 @@ from werewolf.models import Game
 
 
 @pytest.mark.django_db
+def test_get_form_start_game(logged_client, game):
+    url = reverse('start-game', args=(game.pk, ))
+    response = logged_client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
 def test_create_game(game):
     assert game.status == Game.NOT_LAUNCHED
 

--- a/werewolf/werewolf/views.py
+++ b/werewolf/werewolf/views.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView, CreateView, FormView
-from django.views.generic.detail import DetailView, SingleObjectMixin
+from django.views.generic.detail import DetailView, BaseDetailView
 from django.urls import reverse
 from django.http import HttpResponseNotAllowed
 from guardian.shortcuts import assign_perm
@@ -63,7 +63,7 @@ class JoinGame(LoginRequiredMixin, CreateView):
         return super().form_valid(form)
 
 
-class StartGame(FormView, PermissionRequiredMixin, SingleObjectMixin):
+class StartGame(FormView, PermissionRequiredMixin, BaseDetailView):
     template_name = 'start_game.html'
     form_class = StartGameForm
     model = Game


### PR DESCRIPTION
There was an error while getting the forms to start a game.
We get a traceback from a generic view in django :

```
 File "/home/romain/.local/share/virtualenvs/werewolf/lib/python3.8/site-packages/django/views/generic/detail.py", line 94, in get_context_data
    if self.object:
AttributeError: 'StartGame' object has no attribute 'object'
```

This happens because, `SingleObjectMixin` is not made to be used
directly. The code assume that `self.object` is set before the call of
`get_context_data`.

We use now `BaseDetailView` wich do it for use.